### PR TITLE
Add narrative decoding for FHIR and HL7 content

### DIFF
--- a/src/pulsepipe/ingesters/fhir_utils/diagnostic_report_mapper.py
+++ b/src/pulsepipe/ingesters/fhir_utils/diagnostic_report_mapper.py
@@ -27,6 +27,7 @@ from pulsepipe.models import (
     ImagingFinding, PathologyFinding, LabReport, LabObservation, BloodBankReport, BloodBankFinding, MessageCache
 )
 from pulsepipe.utils.log_factory import LogFactory
+from pulsepipe.utils.narrative_decoder import decode_narrative
 from .base_mapper import BaseFHIRMapper, fhir_mapper
 from .extractors import (
     extract_patient_reference,
@@ -207,7 +208,7 @@ class DiagnosticReportMapper(BaseFHIRMapper):
             findings=[finding],
             ordering_provider_id=None,
             performing_facility=None,
-            narrative=resource.get("text", {}).get("div"),
+            narrative=decode_narrative(resource.get("text", {}).get("div")),
             patient_id=patient_id,
             encounter_id=encounter_id,
         )
@@ -250,7 +251,7 @@ class DiagnosticReportMapper(BaseFHIRMapper):
             diagnosis=resource.get("conclusion"),
             staging=None,
             grade=None,
-            narrative=resource.get("text", {}).get("div"),
+            narrative=decode_narrative(resource.get("text", {}).get("div")),
             note=None,
         )
 

--- a/src/pulsepipe/ingesters/fhir_utils/observation_mapper.py
+++ b/src/pulsepipe/ingesters/fhir_utils/observation_mapper.py
@@ -26,6 +26,7 @@ from pulsepipe.models import (
     VitalSign, LabReport, MicrobiologyReport, ImagingReport, PulseClinicalContent, MessageCache
 )
 from pulsepipe.utils.config_loader import load_mapping_config
+from pulsepipe.utils.narrative_decoder import decode_narrative
 from .base_mapper import BaseFHIRMapper, fhir_mapper
 from .observation_helpers import map_simple_imaging, map_simple_lab_observation
 from .extractors import (
@@ -131,7 +132,7 @@ class ObservationMapper(BaseFHIRMapper):
             findings=[finding],
             ordering_provider_id = None,
             performing_facility = None,
-            narrative=resource.get("text", {}).get("div"),
+            narrative=decode_narrative(resource.get("text", {}).get("div")),
             patient_id=patient_id,
             encounter_id=encounter_id,
         )
@@ -153,7 +154,7 @@ class ObservationMapper(BaseFHIRMapper):
             report_type=None,
             collection_date=resource.get("effectiveDateTime"),
             observations=[map_simple_lab_observation(resource)],
-            note=resource.get("text", {}).get("div"),
+            note=decode_narrative(resource.get("text", {}).get("div")),
             patient_id=patient_id,
             encounter_id=encounter_id,
         )

--- a/src/pulsepipe/ingesters/hl7v2_utils/obx_mapper.py
+++ b/src/pulsepipe/ingesters/hl7v2_utils/obx_mapper.py
@@ -24,6 +24,7 @@
 
 from typing import Dict, Any
 from pulsepipe.utils.log_factory import LogFactory
+from pulsepipe.utils.narrative_decoder import decode_narrative
 from .message import Segment
 from .base_mapper import HL7v2Mapper, register_mapper
 from pulsepipe.models import VitalSign, LabObservation, LabReport
@@ -54,7 +55,9 @@ class OBXMapper(HL7v2Mapper):
             code_system = seg.get(3, 3)  # Coding system
             
             # OBX-5: Observation Value
-            value = seg.get(5)
+            raw_value = seg.get(5)
+            # Check if this might be encoded content
+            value = decode_narrative(raw_value) if raw_value else None
             
             # OBX-6: Units
             units = seg.get(6, 1)

--- a/src/pulsepipe/utils/narrative_decoder.py
+++ b/src/pulsepipe/utils/narrative_decoder.py
@@ -1,0 +1,138 @@
+"""
+Utility functions for decoding narrative content that might be encoded in
+base64, hex, or contain HTML that needs to be sanitized.
+"""
+
+import base64
+import binascii
+import re
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+def is_base64(text: str) -> bool:
+    """
+    Check if a string is likely base64 encoded.
+    
+    Args:
+        text: String to check
+        
+    Returns:
+        bool: True if the string appears to be base64 encoded
+    """
+    if not text:
+        return False
+        
+    # Base64 strings are typically multiples of 4 characters
+    # and only contain a specific character set
+    if len(text) % 4 != 0:
+        return False
+    
+    # Base64 pattern: A-Z, a-z, 0-9, +, /, and = for padding
+    pattern = r'^[A-Za-z0-9+/]+={0,2}$'
+    return bool(re.match(pattern, text))
+
+def is_hex(text: str) -> bool:
+    """
+    Check if a string is likely hex encoded.
+
+    Args:
+        text: String to check
+
+    Returns:
+        bool: True if the string appears to be hex encoded
+    """
+    if not text:
+        return False
+
+    # Hex strings typically have an even number of characters
+    # and only contain hexadecimal characters
+    pattern = r'^[A-Fa-f0-9]+$'
+    is_hex_pattern = bool(re.match(pattern, text)) and len(text) % 2 == 0
+
+    # Additional check - try to decode it and see if it succeeds
+    if is_hex_pattern:
+        try:
+            # Try to decode and get ASCII text (printable characters)
+            decoded = binascii.unhexlify(text).decode('utf-8')
+            # If we get mostly printable ASCII, it's likely real hex-encoded content
+            printable_chars = sum(c.isprintable() for c in decoded)
+            return printable_chars / len(decoded) > 0.8
+        except (binascii.Error, UnicodeDecodeError):
+            return False
+
+    return False
+
+def clean_html(html_content: str) -> str:
+    """
+    Remove HTML tags from content, leaving only the text.
+
+    Args:
+        html_content: HTML string to clean
+
+    Returns:
+        str: Plain text with HTML tags removed
+    """
+    if not html_content:
+        return ""
+
+    # Simple HTML tag removal - for complex HTML parsing,
+    # consider using a library like BeautifulSoup
+    clean_text = re.sub(r'<[^>]+>', '', html_content)
+    # Normalize whitespace
+    clean_text = re.sub(r'\s+', ' ', clean_text).strip()
+    return clean_text
+
+def decode_narrative(content: Optional[str], sanitize_html: bool = True) -> Optional[str]:
+    """
+    Attempt to detect and decode encoded narrative content.
+
+    Args:
+        content: Potentially encoded content
+        sanitize_html: Whether to remove HTML tags from the result
+
+    Returns:
+        str: Decoded content or original content if no encoding detected
+    """
+    if not content:
+        return None
+
+    result = content
+    decoded = None
+
+    # Try to detect and decode base64
+    if is_base64(content):
+        try:
+            decoded = base64.b64decode(content).decode('utf-8')
+            logger.debug("Successfully decoded base64 content")
+            result = decoded
+        except (binascii.Error, UnicodeDecodeError) as e:
+            logger.debug(f"Failed to decode potential base64 content: {e}")
+
+    # Try to detect and decode hex
+    elif is_hex(content):
+        try:
+            decoded = binascii.unhexlify(content).decode('utf-8')
+            logger.debug("Successfully decoded hex content")
+            result = decoded
+        except (binascii.Error, UnicodeDecodeError) as e:
+            logger.debug(f"Failed to decode potential hex content: {e}")
+
+    # If detection failed, try a more direct approach for hex
+    # This helps in cases where our detection heuristic might not catch valid hex
+    if not decoded and len(content) % 2 == 0 and all(c in '0123456789ABCDEFabcdef' for c in content):
+        try:
+            decoded = binascii.unhexlify(content).decode('utf-8')
+            # If we get mostly printable characters, it's probably valid hex
+            if sum(c.isprintable() for c in decoded) / len(decoded) > 0.8:
+                logger.debug("Successfully decoded hex content (fallback method)")
+                result = decoded
+        except (binascii.Error, UnicodeDecodeError):
+            pass
+
+    # Clean HTML if requested
+    if sanitize_html and result and ('<' in result and '>' in result):
+        result = clean_html(result)
+
+    return result

--- a/tests/test_narrative_decoder.py
+++ b/tests/test_narrative_decoder.py
@@ -1,0 +1,98 @@
+import unittest
+import base64
+import binascii
+from src.pulsepipe.utils.narrative_decoder import (
+    is_base64, is_hex, clean_html, decode_narrative
+)
+
+class TestNarrativeDecoder(unittest.TestCase):
+    def test_is_base64(self):
+        # Valid base64 strings
+        self.assertTrue(is_base64("SGVsbG8gV29ybGQ="))  # "Hello World"
+        self.assertTrue(is_base64("VGhpcyBpcyBhIHRlc3Q="))  # "This is a test"
+        
+        # Invalid base64 strings
+        self.assertFalse(is_base64("Not base64!"))
+        self.assertFalse(is_base64("123"))
+        self.assertFalse(is_base64(""))
+        self.assertFalse(is_base64(None))
+    
+    def test_is_hex(self):
+        # Valid hex strings
+        self.assertTrue(is_hex("48656c6c6f20576f726c64"))  # "Hello World"
+        self.assertTrue(is_hex("54657374"))  # "Test"
+        
+        # Invalid hex strings
+        self.assertFalse(is_hex("Not hex!"))
+        self.assertFalse(is_hex("123G"))  # 'G' isn't valid hex
+        self.assertFalse(is_hex(""))
+        self.assertFalse(is_hex(None))
+        self.assertFalse(is_hex("123"))  # Odd length
+    
+    def test_clean_html(self):
+        html = "<div>This is <b>formatted</b> text with <i>styles</i>.</div>"
+        expected = "This is formatted text with styles."
+        self.assertEqual(clean_html(html), expected)
+        
+        # Test with empty inputs
+        self.assertEqual(clean_html(""), "")
+        self.assertEqual(clean_html(None), "")
+    
+    def test_decode_narrative_base64(self):
+        # Base64 encoded "This is clinical information"
+        base64_text = "VGhpcyBpcyBjbGluaWNhbCBpbmZvcm1hdGlvbg=="
+        expected = "This is clinical information"
+        result = decode_narrative(base64_text)
+        self.assertEqual(result, expected)
+    
+    def test_decode_narrative_hex(self):
+        # Create a test string
+        test_string = "Patient note"
+        # Convert to hex
+        hex_text = test_string.encode('utf-8').hex()
+
+        # Test our utility's ability to handle manually provided hex
+        result = decode_narrative(hex_text, sanitize_html=False)
+
+        # For this test, we'll directly call the binascii function
+        # since our automatic detection might need tuning
+        manual_result = binascii.unhexlify(hex_text).decode('utf-8')
+
+        # Verify manual decoding works
+        self.assertEqual(manual_result, test_string)
+        # Verify our function matches manual result
+        self.assertEqual(result, manual_result)
+    
+    def test_decode_narrative_html(self):
+        # HTML content
+        html = "<div>Patient has <b>fever</b> and <i>cough</i>.</div>"
+        expected = "Patient has fever and cough."
+        result = decode_narrative(html)
+        self.assertEqual(result, expected)
+    
+    def test_decode_narrative_with_html_in_base64(self):
+        # Base64 encoded HTML
+        html = "<div>Patient has <b>fever</b> and <i>cough</i>.</div>"
+        base64_html = base64.b64encode(html.encode('utf-8')).decode('utf-8')
+        expected = "Patient has fever and cough."
+        result = decode_narrative(base64_html)
+        self.assertEqual(result, expected)
+    
+    def test_decode_narrative_plaintext(self):
+        # Plain text that shouldn't be modified
+        plaintext = "Regular patient notes without encoding"
+        result = decode_narrative(plaintext)
+        self.assertEqual(result, plaintext)
+    
+    def test_decode_narrative_empty(self):
+        # Empty or None values
+        self.assertIsNone(decode_narrative(""))
+        self.assertIsNone(decode_narrative(None))
+    
+    def test_decode_narrative_disable_html_sanitization(self):
+        html = "<div>HTML <b>content</b></div>"
+        result = decode_narrative(html, sanitize_html=False)
+        self.assertEqual(result, html)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_narrative_decoding_direct.py
+++ b/tests/test_narrative_decoding_direct.py
@@ -1,0 +1,65 @@
+import unittest
+import base64
+import binascii
+
+from src.pulsepipe.utils.narrative_decoder import decode_narrative
+
+class TestNarrativeDecodingDirect(unittest.TestCase):
+    """Test direct decoding of narratives to verify the functionality works"""
+    
+    def test_decode_base64_narrative(self):
+        """Test decoding base64 encoded narrative text"""
+        # Sample text
+        original_text = "This is clinical information that needs to be decoded"
+        
+        # Base64 encode it
+        encoded_text = base64.b64encode(original_text.encode('utf-8')).decode('utf-8')
+        
+        # Decode using our utility
+        decoded_text = decode_narrative(encoded_text)
+        
+        # Verify
+        self.assertEqual(decoded_text, original_text)
+    
+    def test_decode_hex_narrative(self):
+        """Test decoding hex encoded narrative text"""
+        # Sample text
+        original_text = "This is clinical information in hex format"
+        
+        # Hex encode it
+        encoded_text = original_text.encode('utf-8').hex()
+        
+        # Decode using our utility
+        decoded_text = decode_narrative(encoded_text)
+        
+        # Verify
+        self.assertEqual(decoded_text, original_text)
+    
+    def test_decode_html_narrative(self):
+        """Test HTML cleaning in narratives"""
+        html_text = "<div><p>Patient has <b>acute sinusitis</b> with <i>fever</i>.</p></div>"
+        expected_text = "Patient has acute sinusitis with fever."
+        
+        # Process with our decoder
+        processed_text = decode_narrative(html_text)
+        
+        # Verify HTML is cleaned
+        self.assertEqual(processed_text, expected_text)
+    
+    def test_decode_base64_html_narrative(self):
+        """Test decoding base64 encoded HTML narrative"""
+        # Original HTML
+        original_html = "<div><p>Patient has <b>pneumonia</b> in the <i>right lung</i>.</p></div>"
+        expected_text = "Patient has pneumonia in the right lung."
+        
+        # Base64 encode it
+        encoded_html = base64.b64encode(original_html.encode('utf-8')).decode('utf-8')
+        
+        # Decode using our utility
+        decoded_text = decode_narrative(encoded_html)
+        
+        # Verify
+        self.assertEqual(decoded_text, expected_text)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_narrative_decoding_integration.py
+++ b/tests/test_narrative_decoding_integration.py
@@ -1,0 +1,73 @@
+import unittest
+import base64
+import binascii
+from unittest.mock import MagicMock, patch
+
+from src.pulsepipe.utils.narrative_decoder import decode_narrative
+from src.pulsepipe.ingesters.fhir_utils.document_reference_mapper import DocumentReferenceMapper
+from src.pulsepipe.models.document_reference import DocumentReference
+
+class TestNarrativeDecodingIntegration(unittest.TestCase):
+    """
+    Test narrative decoding directly in the mappers without depending on
+    full content models which have strict validation requirements.
+    """
+        
+    def test_document_reference_mapper_decodes_base64(self):
+        """Test base64 decoding in DocumentReference mapper directly"""
+        # Plain text content to encode
+        plain_content = "This is test clinical content for the patient."
+        encoded_content = base64.b64encode(plain_content.encode('utf-8')).decode('utf-8')
+
+        # Create a FHIR attachment with encoded data
+        attachment = {
+            "contentType": "text/plain",
+            "data": encoded_content
+        }
+
+        # Use the decode_narrative function directly within the mapper
+        mapper = DocumentReferenceMapper()
+
+        # Create a patched content_text to hold the result
+        content_text = mapper._decode_attachment_content(attachment)
+
+        # Verify the content was decoded
+        self.assertEqual(content_text, plain_content)
+
+    def test_document_reference_mapper_decodes_hex(self):
+        """Test hex decoding in DocumentReference mapper directly"""
+        # Plain text content to encode
+        plain_content = "This is test clinical content for the patient."
+        encoded_content = plain_content.encode('utf-8').hex()
+
+        # Create a FHIR attachment with encoded data
+        attachment = {
+            "contentType": "text/plain",
+            "data": encoded_content
+        }
+
+        # Use the decode_narrative function directly within the mapper
+        mapper = DocumentReferenceMapper()
+
+        # Create a patched content_text to hold the result
+        content_text = mapper._decode_attachment_content(attachment)
+
+        # Verify the content was decoded
+        self.assertEqual(content_text, plain_content)
+        
+    def test_html_narrative_decoding(self):
+        """Test direct decoding of HTML narrative"""
+        # Create an HTML narrative
+        html = "<div xmlns='http://www.w3.org/1999/xhtml'><p>Patient has <b>mild infiltrates</b> in the <i>right lower lobe</i>.</p></div>"
+
+        # Decode directly
+        decoded = decode_narrative(html)
+
+        # Verify HTML tags were cleaned
+        self.assertNotIn("<b>", decoded, "HTML tags were not cleaned")
+        self.assertNotIn("<i>", decoded, "HTML tags were not cleaned")
+        self.assertIn("mild infiltrates", decoded, "Content was lost in cleaning")
+        self.assertIn("right lower lobe", decoded, "Content was lost in cleaning")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements utility for decoding narratives in different healthcare formats, supporting base64, hex, and HTML sanitization. Integrates with diagnostic reports, document references, and observations to improve readability of clinical narratives.