### PR TITLE
Fix database connection timeout handling and improve error diagnostics

### DIFF
--- a/pulsepipe.yaml
+++ b/pulsepipe.yaml
@@ -23,6 +23,7 @@
 
 persistence:
   type: mongodb  # sqlite | postgresql | mongodb
+  connection_timeout: 5  # seconds for database connection timeout
 
   sqlite:
     db_path: .pulsepipe/state/ingestion.sqlite3
@@ -35,6 +36,9 @@ persistence:
     password: ""
     replica_set: ""
     read_preference: primaryPreferred
+    connect_timeout_ms: 5000  # Connection timeout in milliseconds
+    server_selection_timeout_ms: 5000  # Server selection timeout in milliseconds
+    socket_timeout_ms: 5000  # Socket timeout in milliseconds
 
   postgresql:
     host: localhost

--- a/src/pulsepipe/adapters/file_watcher_bookmarks/factory.py
+++ b/src/pulsepipe/adapters/file_watcher_bookmarks/factory.py
@@ -53,11 +53,15 @@ def create_bookmark_store(config: dict):
             return CommonBookmarkStore(connection, dialect)
         except Exception as e:
             elapsed = time.time() - start_time
-            db_type = persistence_config.get("database", {}).get("type", "unknown")
+            # Get database type from either persistence.type or persistence.database.type
+            db_type = (
+                persistence_config.get("type") or 
+                persistence_config.get("database", {}).get("type", "unknown")
+            )
             
             # Use comprehensive diagnostics for better error reporting
             try:
-                raise_database_diagnostic_error(config, timeout=5)
+                raise_database_diagnostic_error(config)
             except DatabaseDiagnosticError as diag_error:
                 # Re-raise with bookmark store context
                 enhanced_message = (
@@ -114,7 +118,7 @@ def create_bookmark_store(config: dict):
             
             # Use comprehensive diagnostics 
             try:
-                raise_database_diagnostic_error(config, timeout=5)
+                raise_database_diagnostic_error(config)
             except DatabaseDiagnosticError as diag_error:
                 enhanced_message = (
                     f"🔒 PostgreSQL bookmark store initialization failed\n"
@@ -158,7 +162,7 @@ def create_bookmark_store(config: dict):
             
             # Use comprehensive diagnostics
             try:
-                raise_database_diagnostic_error(config, timeout=5)
+                raise_database_diagnostic_error(config)
             except DatabaseDiagnosticError as diag_error:
                 enhanced_message = (
                     f"🔒 MongoDB bookmark store initialization failed\n"

--- a/src/pulsepipe/cli/main.py
+++ b/src/pulsepipe/cli/main.py
@@ -1037,7 +1037,7 @@ def _load_database_commands():
             if issue_type in ["connection_working", "connection_slow_but_working"]:
                 click.echo("✅ Database connection is healthy!")
                 
-                db_type = diagnostic_info.get("config_type", "unknown")
+                db_type = diagnostic_info.get("config_type") or "unknown"
                 connection_time = diagnostic_info.get("connection_timeout", total_time)
                 
                 click.echo(f"Database type: {db_type}")


### PR DESCRIPTION
- Add connection_timeout setting to persistence config with MongoDB-specific timeouts
- Update database diagnostics to use configurable timeouts and handle None config_type gracefully
- Improve bookmark factory error handling with enhanced diagnostic messages
- Update CLI commands to use ConfigurationError for better error reporting
- Fix persistence factory to properly handle MongoDB timeout settings
- Update unit tests to match new config structure and diagnostic behavior